### PR TITLE
`should_match_body_to` matcher accepts a regex

### DIFF
--- a/lib/shouldi/matchers/plug.ex
+++ b/lib/shouldi/matchers/plug.ex
@@ -60,6 +60,8 @@ defmodule ShouldI.Matchers.Plug do
   @doc """
   The connection body (`connection.resp_body`) should match the expected result.
 
+  Accepts a String or a Regex as the expected result to match.
+
       setup context do
         some_plug_call_returning_a_context_having_a_connection_key
       end
@@ -68,7 +70,15 @@ defmodule ShouldI.Matchers.Plug do
   """
   defmatcher should_match_body_to(expected) do
     quote do
-      assert var!(context).connection.resp_body =~ ~r"#{unquote(expected)}"
+      plug_should_match_body_to(unquote(expected), var!(context))
     end
+  end
+
+  def plug_should_match_body_to( string, context ) when is_binary(string) do
+    assert context.connection.resp_body =~ ~r/#{string}/
+  end
+
+  def plug_should_match_body_to( regex, context ) do
+    assert context.connection.resp_body =~ regex
   end
 end

--- a/lib/shouldi/matchers/plug.ex
+++ b/lib/shouldi/matchers/plug.ex
@@ -70,15 +70,8 @@ defmodule ShouldI.Matchers.Plug do
   """
   defmatcher should_match_body_to(expected) do
     quote do
-      plug_should_match_body_to(unquote(expected), var!(context))
+      assert var!(context).connection.resp_body =~ unquote(expected)
     end
   end
 
-  def plug_should_match_body_to( string, context ) when is_binary(string) do
-    assert context.connection.resp_body =~ ~r/#{string}/
-  end
-
-  def plug_should_match_body_to( regex, context ) do
-    assert context.connection.resp_body =~ regex
-  end
 end

--- a/test/plug_matcher_test.exs
+++ b/test/plug_matcher_test.exs
@@ -13,5 +13,6 @@ defmodule PlugMatcherTest do
   with "context" do
     should_respond_with :success
     should_match_body_to "test"
+    should_match_body_to ~r/test/
   end
 end


### PR DESCRIPTION
Hello!

I think it would be nice if this plug matcher could also accept a regex. (I found this handy as it's hard to know where the white-space will be in the body, so often my string literals would not match).

Very new to Elixir, so would love to hear get any feedback here as well.

Cheers,
Louis