### PR TITLE
fix when setup callback :ok return value

### DIFF
--- a/lib/shouldi.ex
+++ b/lib/shouldi.ex
@@ -79,7 +79,13 @@ defmodule ShouldI do
 
   defmacro setup(var \\ quote(do: _), [do: block]) do
     quote do
-      ExUnit.Callbacks.setup(unquote(var), do: {:ok, unquote(block)})
+      ExUnit.Callbacks.setup unquote(var) do
+        case unquote(block) do
+          :ok -> :ok
+          {:ok, list} -> {:ok, list}
+          map -> {:ok, map}
+        end
+      end
     end
   end
 

--- a/lib/shouldi/having.ex
+++ b/lib/shouldi/having.ex
@@ -42,7 +42,7 @@ defmodule ShouldI.Having do
     end
   end
 
-  defmacro setup(var \\ quote(do: _), [do: block]) do
+  defmacro setup(var \\ quote(do: context), [do: block]) do
     if_quote =
       quote unquote: false do
         starts_with?(unquote(shouldi_having_path), shouldi_path)
@@ -54,7 +54,11 @@ defmodule ShouldI.Having do
         shouldi_path = unquote(var)[:shouldi_having_path] || []
 
         if unquote(if_quote) do
-          {:ok, unquote(block)}
+          case unquote(block) do
+            :ok -> :ok
+            {:ok, list} -> {:ok, list}
+            map  -> {:ok, map}
+          end
         else
           :ok
         end

--- a/test/should_test.exs
+++ b/test/should_test.exs
@@ -39,3 +39,44 @@ defmodule ShouldTest do
     end
   end
 end
+
+defmodule ShouldSetupTest do
+  use ShouldI
+
+  setup do
+    :ok
+  end
+
+  setup do
+    {:ok, [context: :setup]}
+  end
+
+  setup context do
+    assert context[:context] == :setup
+    context |> Dict.put(:context, :setup_context)
+  end
+
+  should "setup context", context do
+    assert context[:context] == :setup_context
+  end
+
+  having "having context" do
+
+    setup do
+      :ok
+    end
+
+    setup do
+      {:ok, [context: :setup_in_having]}
+    end
+
+    setup context do
+      assert context[:context] == :setup_in_having
+      context |> Dict.put(:context, :setup_in_having_context)
+    end
+
+    test "setup context", context do
+      assert context[:context] == :setup_in_having_context
+    end
+  end
+end


### PR DESCRIPTION
I remove test and put only example which is return `:ok` at setup.
When `use ExUnit.Case`, this test succeeded. But using `shouli`, this test fail because of runtime error.

related: use on_exit callback #28

BTW, if we set `context` like test case which I commented out in this PR even don't set any value into the `context` and run test, the test success. If using `context` is limitation in `shouldi`, I will `context` in this case and close this PR.
